### PR TITLE
Update PsychroLib, open the pinning

### DIFF
--- a/custom_components/dewpoint/manifest.json
+++ b/custom_components/dewpoint/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/ehn/home-assistant-dewpoint",
   "issue_tracker": "https://github.com/ehn/home-assistant-dewpoint/issues",
   "codeowners": ["@miguelangel-nubla", "@lultimouomo", "@ehn"],
-  "requirements": ["psychrolib==2.1.0"],
+  "requirements": ["psychrolib>=2.1.0"],
   "version": "0.0.1"
 }


### PR DESCRIPTION
hard pinning is bad in general, can confirm it works perfect on Python 3.9 with PsychroLib-2.5.0